### PR TITLE
[bugfix] this.$refs.importantDates was not defined

### DIFF
--- a/frontend/src/components/ContactsEdit.vue
+++ b/frontend/src/components/ContactsEdit.vue
@@ -645,9 +645,10 @@ export default defineComponent({
                 (
                     this.$refs.socialMedia as SocialMediaEdit
                 ).hasUnsavedChanges() ||
-                (
-                    this.$refs.importantDates as ImportantDatesEdit
-                ).hasUnsavedChanges()
+                (this.$refs.importantDates &&
+                    (
+                        this.$refs.importantDates as ImportantDatesEdit
+                    ).hasUnsavedChanges())
             );
         },
         freshEmailAddress(): Record<string, any> {


### PR DESCRIPTION
# Description

In the BusinesssCardEdit view, `this.$refs.importantDates` was not defined, which resulted in the edit view being unable to be closed (since the `hasUnsavedChanges()` method threw an Error).

We modify the code to only access `this.$refs.importantDates` if it is truthy

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have used appropriate and understandable variable names 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] My code has been linted and meets coding standards
